### PR TITLE
Rework schematron builder

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -28,12 +28,12 @@ The following tools are used to generate target files from sources:
 
 Depending on your installation, a tool may be run in one of these ways:
 
-| Mode        | Command                                                                         |
-|-------------|---------------------------------------------------------------------------------|
-| Python      | `python template2schematron.py`                                                 |
-| uv (file)   | `uv run python template2schematron.py` |
-| uv (module) | `uv run python -m template2schematron` |
-| Script      | `schematron-builder`                                                            |
+| Mode        | Command                               |
+|-------------|---------------------------------------|
+| Python      | `python schematron_builder.py`        |
+| uv (file)   | `uv run python schematron_builder.py` |
+| uv (module) | `uv run python -m schematron_builder` |
+| Script      | `schematron-builder`                  |
 
 ## General rules applying to all tools
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,6 +24,17 @@ The following tools are used to generate target files from sources:
 | [xml_snippets](xml_snippets/README.md)       | Python | `src/templates` | `site/xml-snippets` | **Extracts XML Snippets** from templates.                                                                                               |
 | [pycore](pycore/README.md)             | xquery | -               | -                   | **Generates Markdown tables** from a XSD schema.                                                                                        |
 
+## How to run a tool
+
+Depending on your installation, a tool may be run in one of these ways:
+
+| Mode        | Command                                                                         |
+|-------------|---------------------------------------------------------------------------------|
+| Python      | `python template2schematron.py`                                                 |
+| uv (file)   | `uv run python template2schematron.py` |
+| uv (module) | `uv run python -m template2schematron` |
+| Script      | `schematron-builder`                                                            |
+
 ## General rules applying to all tools
 
 - Default input folders and/or output folders are used if folders are not explicitly given (not all tools yet).

--- a/tools/configuration.py
+++ b/tools/configuration.py
@@ -5,6 +5,7 @@ PROJECT_DIR=files()
 # Source documents
 DOCS_DIR = PROJECT_DIR.joinpath("../src")
 TEMPLATES_DIR = DOCS_DIR.joinpath("templates")
+TEMPLATES_PREFIX =  "ch-profile-"
 
 JEKYLL_DIR = PROJECT_DIR.joinpath("../jekyll")
 

--- a/tools/schematron_builder/README.md
+++ b/tools/schematron_builder/README.md
@@ -4,7 +4,7 @@ This tool generates Schematron validation files from XML templates with special 
 
 ## Overview
 
-The `template2schematron.py` script processes XML templates containing special comment markers and generates Schematron (.sch) files that enforce the Swiss NeTEX profile rules.
+The `schematron_builder.py` script processes XML templates containing special comment markers and generates Schematron (.sch) files that enforce the Swiss NeTEX profile rules.
 
 ## Features
 
@@ -44,7 +44,7 @@ input folder (templates folder) and creates schematron files from them.
 
 In order to get a detailed usage message, Run the tool with option `-h` or `--help`:
 ```bash
-python template2schematron.py -h
+python schematron_builder.py -h
 ```
 Or, with installed script:
 ```bash
@@ -58,7 +58,7 @@ See [the tools README](../README.md#how-to-run-a-tool) about how to run a tool.
 Build schematron from individual template:
 
 ```bash
-python template2schematron.py \
+python schematron_builder.py \
     -t templates/ch-profile_export-timetable_file.xml \
     -x xsd/xsd/NeTEx_publication.xsd \
     -i templates \
@@ -68,7 +68,7 @@ python template2schematron.py \
 or, with uv:
 
 ```bash
-uv python -m template2schematron \
+uv python -m schematron_builder \
     -t templates/ch-profile_export-timetable_file.xml
 ```
 

--- a/tools/schematron_builder/README.md
+++ b/tools/schematron_builder/README.md
@@ -17,7 +17,14 @@ The `template2schematron.py` script processes XML templates containing special c
 ## Supported functionality
 For details on the functionality read [the documentation in the templates folder](../../templates/README.md).
 f
+
 ## Installation
+
+### Build tools with uv
+
+The recommended way is to [build the tools with uv] (../README.md#how-to-setup-and-run-the-build).
+
+### Individual installation
 
 Requires Python 3.6+ and lxml:
 
@@ -27,24 +34,28 @@ pip install lxml
 
 ## Usage
 
+The tool can be run in two different modes:
+
+- Create schematron file from single template file
+- Create schematron files from all templates in input directory
+
+The default behavior is, that it looks for template files with prefix 'ch_profile_' in the 
+input folder (templates folder) and creates schematron files from them.
+
+In order to get a detailed usage message, Run the tool with option `-h` or `--help`:
 ```bash
-python template2schematron.py \
-    -t TEMPLATE_FILE \
-    -x XSD_FILE \
-    -i INPUT_FOLDER \
-    -o OUTPUT_FILE \
-    [-v]
+python template2schematron.py -h
+```
+Or, with installed script:
+```bash
+schematron-builder -h
 ```
 
-### Parameters
+See [the tools README](../README.md#how-to-run-a-tool) about how to run a tool.
 
-- `-t, --template`: Template XML file containing ch-root regions
-- `-x, --xsd`: XSD file (path is stored but not currently used for validation)
-- `-i, --input-folder`: Folder with referenced XML fragment files
-- `-o, --output`: Output Schematron (.sch) file
-- `-v, --verbose`: Enable verbose logging
+### Usage Examples
 
-### Example
+Build schematron from individual template:
 
 ```bash
 python template2schematron.py \
@@ -54,10 +65,22 @@ python template2schematron.py \
     -o generated/schematrons/ch-profile_export_timetable_file.sch \
     -v
 ```
+or, with uv:
 
-## Build Script
+```bash
+uv python -m template2schematron \
+    -t templates/ch-profile_export-timetable_file.xml
+```
 
-The `build_schemas.sh` script automates building all schematron files:
+## Build Scripts
+
+### Tools script
+
+The tools build installs a wrapper script `schematron-builder` to `.venv/bin`.
+
+### build_schemas.sh
+
+The `build_schemas.sh` script can be used to build all schematron files:
 
 ```bash
 # Basic usage (default settings)

--- a/tools/schematron_builder/build_schemas.sh
+++ b/tools/schematron_builder/build_schemas.sh
@@ -7,7 +7,7 @@
 INPUT_FOLDER="templates"
 OUTPUT_FOLDER="generated/schematrons"
 XSD_FILE="xsd/xsd/NeTEx_publication.xsd"
-PYTHON_SCRIPT="tools/schematron_builder/template2schematron.py"
+PYTHON_SCRIPT="tools/schematron_builder/schematron_builder.py"
 LOG_FILE="generated/schematrons/build.log"
 CLEAN_OUTPUT=false
 VALIDATE_OUTPUT=false

--- a/tools/schematron_builder/schematron_builder.py
+++ b/tools/schematron_builder/schematron_builder.py
@@ -1,37 +1,11 @@
 #!/usr/bin/env python3
 """
-template2schematron.py
-
 Generates Schematron validation files from XML templates with special comment annotations.
-
-Requires lxml for robust XML processing and XPath support.
-
-Print usage - run with option -h:
-uv run python template2schematron.py -h
-
-Examples:
-    # Process a single ch-profile template
-    python template2schematron.py \
-        -t src/templates/ch-profile_export-timetable_file.xml \
-        -x xsd/xsd/NeTEx_publication.xsd \
-        -i src/templates \
-        -o site/schematrons \
-        -v
-
-    # Process all ch-profile templates (using uv)
-    uv run python template2schematron.py
-
-    # Process single template using custom root element (default: PublicationDelivery)
-    uv run python template2schematron.py \
-        -t templates/custom_template.xml \
-        -r CustomRootElement
 """
-
 import sys
 import os
 import re
 import argparse
-from contextlib import nullcontext
 
 from tools.configuration import XSD_FILE_PATH, TEMPLATES_DIR, SITE_SCHEMATRON_DIR
 

--- a/tools/schematron_builder/template2schematron.py
+++ b/tools/schematron_builder/template2schematron.py
@@ -31,6 +31,7 @@ import sys
 import os
 import re
 import argparse
+from contextlib import nullcontext
 
 from tools.configuration import XSD_FILE_PATH, TEMPLATES_DIR, SITE_SCHEMATRON_DIR
 
@@ -71,9 +72,12 @@ RE_CH_COMMAND = re.compile(r'\b(ch-[a-zA-Z0-9_-]+)', re.IGNORECASE)
 # Verbose debug toggle (set via CLI)
 VERBOSE = False
 
+DEFAULT_XML_FILE_PREFIX="ch-profile_"
+
 def read_file(path):
     """Read file content with UTF-8 encoding."""
-    print (f'Reading file: ${path}')
+    if VERBOSE:
+        print (f'Reading ${path}')
     try:
         with open(path, 'r', encoding='utf-8') as f:
             return f.read()
@@ -607,8 +611,6 @@ def process_element_tree(elem, builder, parent_context_path='', input_folder='.'
     else:
         elem_abs_path = ns_join(builder, parent_context_path, tag_local)
         parent_abs_path = parent_context_path
-    if elem_abs_path == "netex:PublicationDelivery/netex:dataObjects/netex:CompositeFrame/netex:frames/netex:ServiceFrame":
-        print("here")
     # Partition direct children
     nodes = list(elem)
     child_elements = []
@@ -763,6 +765,10 @@ def generate_schematron_from_template(template_path: str, input_folder: str, out
     name = template_name.split('.')[0]
     schematron_name = f"{name}.sch"
     regions = extract_regions(txt)
+
+    if VERBOSE:
+        print(f"Processing template {template_name} from {template_path}.")
+
     if not regions:
         print(
             f'Warning: no regions found with root in {template_name}; attempting to process entire file',
@@ -820,9 +826,20 @@ def generate_schematron_from_template(template_path: str, input_folder: str, out
 
     schematron_path = f'{output_folder}/{schematron_name}'
     write_file(schematron_path, schematron_content)
-    print(f'Created {schematron_name}: {schematron_builder.rules_created} rules.')
+    print(f'-> Created {schematron_name}: {schematron_builder.rules_created} rules.')
 
-def generate_all_schematrons(input_folder: str, output_folder: str, xsd_path: str, root_element: str):
+def template_file_filter(file_name: str, prefix: str, postfix: str) -> bool:
+    """
+    Filters template files according to prefix and postfix of file names.
+    """
+    filter = True;
+    if postfix:
+        filter = filter and file_name.endswith(postfix)
+    if prefix:
+        filter = filter and file_name.startswith(prefix)
+    return filter
+
+def generate_all_schematrons(input_folder: str, prefix: str, output_folder: str, xsd_path: str, root_element: str):
     """
      Generates schematron files from all templates.
 
@@ -831,17 +848,20 @@ def generate_all_schematrons(input_folder: str, output_folder: str, xsd_path: st
      param: schematron_builder: SchematronBuilder object
      param: root_element: Schema root element, e.g. PublicationDelivery
      """
-    templates = [os.path.join(input_folder, f) for f in os.listdir(input_folder) if f.endswith('.xml')]
+    print(f"Processing templates from {input_folder}.")
+
+    templates = [os.path.join(input_folder, f) for f in os.listdir(input_folder) if template_file_filter(f, prefix, '.xml')]
 
     schematron_builder = SchematronBuilder(xsd_path)
     for template_path in templates:
         generate_schematron_from_template(template_path, input_folder, output_folder, schematron_builder, root_element)
 
     print(f"Processed {len(templates)} templates.")
+    print(f"Schematrons written to {output_folder}.")
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description=f"Generates Schematrons from XML templates and fragments. Processes all templates in {TEMPLATES_DIR} or a single template if -t or --template is used."
+        description=f"Generates Schematrons from XML templates and fragments. Processes all templates in an input folder, or a single template if -t or --template is used."
     )
     parser.add_argument('-t', '--template', default=None, required=False,
         help='Template XML file containing ch-start/ch-stop regions (Processes all templates in input folder if None).'
@@ -852,6 +872,8 @@ def parse_args():
                         help=f'Input folder containing XML templates (Default = {TEMPLATES_DIR})')
     parser.add_argument('-o', '--output', default=SITE_SCHEMATRON_DIR,
                         help=f'Output folder for Schematron (.sch) files (Default = {SITE_SCHEMATRON_DIR})')
+    parser.add_argument('-p', '--prefix', default=DEFAULT_XML_FILE_PREFIX, help=f'Prefix for XML files (Default = {DEFAULT_XML_FILE_PREFIX}).')
+    parser.add_argument('-a', '--all', default=False, action='store_true', help='Build all - ignore XML file prefix (Default = False).')
     parser.add_argument(
         '-r', '--root-element',
         default='PublicationDelivery',
@@ -860,6 +882,11 @@ def parse_args():
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose logging.')
     return parser.parse_args()
 
+def evaluate_prefix(prefix: str, all: bool) -> str | None:
+    if all:
+        return None
+    else:
+        return prefix
 
 def main():
     global VERBOSE
@@ -890,7 +917,8 @@ def main():
         schematron_builder = SchematronBuilder(xsd_path)
         generate_schematron_from_template(template_path, input_folder, output_folder, schematron_builder, root_element)
     else:
-        generate_all_schematrons(input_folder, output_folder, xsd_path, root_element)
+        prefix = evaluate_prefix(args.prefix, args.all)
+        generate_all_schematrons(input_folder, prefix, output_folder, xsd_path, root_element)
 
 if __name__ == '__main__':
     main()

--- a/tools/toolchain.py
+++ b/tools/toolchain.py
@@ -3,10 +3,10 @@ import shutil
 from pathlib import Path
 
 from tools.configuration import DOCS_DIR, SITE_DIR, XSD_FILE_PATH, SITE_TABLES_DIR, TEMPLATES_DIR, JEKYLL_DIR, \
-    SITE_XML_SNIPPETS_DIR, SITE_TEMPLATES_DIR, SITE_SCHEMATRON_DIR
+    SITE_XML_SNIPPETS_DIR, SITE_TEMPLATES_DIR, SITE_SCHEMATRON_DIR, TEMPLATES_PREFIX
 from tools.expand_docs.expand_docs import expand_docs
 from tools.md_builder.md_builder import build_markdown_tables
-from tools.schematron_builder.template2schematron import generate_all_schematrons
+from tools.schematron_builder.schematron_builder import generate_all_schematrons
 from tools.xml_snippets.build_xml_snippets import generate_all_snippets
 
 def clean(dir: str):
@@ -32,7 +32,7 @@ def generate_xml_snippets():
     generate_all_snippets(TEMPLATES_DIR, SITE_XML_SNIPPETS_DIR)
 
 def generate_schematrons():
-    generate_all_schematrons(TEMPLATES_DIR, SITE_SCHEMATRON_DIR, XSD_FILE_PATH, 'PublicationDelivery')
+    generate_all_schematrons(TEMPLATES_DIR, TEMPLATES_PREFIX, SITE_SCHEMATRON_DIR, XSD_FILE_PATH, 'PublicationDelivery')
 
 def generate_docs():
     expand_docs(DOCS_DIR, SITE_DIR)


### PR DESCRIPTION
Addresses https://github.com/openTdataCH/netexRealisationGuideSwitzerland/issues/108.

- New options allow to run schematron builder on all xml files (-a or --all) or filtered by prefix (-p or --prefix, default "ch-profile_")
- Renamed to schematron_builder.py
- Reworked tool documentation 